### PR TITLE
feat: improve dashboard and status overview

### DIFF
--- a/castmail2list/app.py
+++ b/castmail2list/app.py
@@ -38,6 +38,7 @@ from .utils import (
     get_version_info,
     is_email_a_list,
     redact,
+    time_ago,
 )
 from .views.api import api1
 from .views.auth import auth
@@ -223,6 +224,7 @@ def create_app(  # noqa: PLR0915
         is_email_a_list=is_email_a_list,  # type: ignore[ty:invalid-argument-type]
         get_list_by_id=get_list_by_id,  # type: ignore[ty:invalid-argument-type]
     )
+    app.jinja_env.filters["time_ago"] = time_ago
 
     # Register error handlers
     register_error_handlers(app)

--- a/castmail2list/status.py
+++ b/castmail2list/status.py
@@ -134,7 +134,8 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
             "hours_24": [
                 {
                     "mid": msg.message_id,
-                    "subject": msg.subject,
+                    "list_id": msg.list_id,
+                    "bounced_recipient": msg.error_info.get("bounced_recipients", ""),
                     "received_at": msg.received_at,
                 }
                 for msg in bounce_hours_24
@@ -142,7 +143,8 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
             "days_7": [
                 {
                     "mid": msg.message_id,
-                    "subject": msg.subject,
+                    "list_id": msg.list_id,
+                    "bounced_recipient": msg.error_info.get("bounced_recipients", ""),
                     "received_at": msg.received_at,
                 }
                 for msg in bounce_days_7
@@ -150,7 +152,8 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
             "last_5": [
                 {
                     "mid": msg.message_id,
-                    "subject": msg.subject,
+                    "list_id": msg.list_id,
+                    "bounced_recipient": msg.error_info.get("bounced_recipients", ""),
                     "received_at": msg.received_at,
                 }
                 for msg in bounce_last_5

--- a/castmail2list/status.py
+++ b/castmail2list/status.py
@@ -70,15 +70,30 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
         "email_in": {
             "count": len(email_in_all),
             "hours_24": [
-                {"mid": msg.message_id, "list_id": msg.list_id, "subject": msg.subject}
+                {
+                    "mid": msg.message_id,
+                    "list_id": msg.list_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
                 for msg in email_in_hours_24
             ],
             "days_7": [
-                {"mid": msg.message_id, "list_id": msg.list_id, "subject": msg.subject}
+                {
+                    "mid": msg.message_id,
+                    "list_id": msg.list_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
                 for msg in email_in_days_7
             ],
             "last_5": [
-                {"mid": msg.message_id, "list_id": msg.list_id, "subject": msg.subject}
+                {
+                    "mid": msg.message_id,
+                    "list_id": msg.list_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
                 for msg in email_in_all[:5]
             ],
         },
@@ -90,6 +105,7 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "list_id": msg.list_id,
                     "subject": msg.subject,
                     "status": msg.status,
+                    "received_at": msg.received_at,
                 }
                 for msg in email_in_fail_hours_24
             ],
@@ -99,6 +115,7 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "list_id": msg.list_id,
                     "subject": msg.subject,
                     "status": msg.status,
+                    "received_at": msg.received_at,
                 }
                 for msg in email_in_fail_days_7
             ],
@@ -108,16 +125,36 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "list_id": msg.list_id,
                     "subject": msg.subject,
                     "status": msg.status,
+                    "received_at": msg.received_at,
                 }
                 for msg in email_in_fail_all[:5]
             ],
         },
         "bounces": {
             "hours_24": [
-                {"mid": msg.message_id, "subject": msg.subject} for msg in bounce_hours_24
+                {
+                    "mid": msg.message_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
+                for msg in bounce_hours_24
             ],
-            "days_7": [{"mid": msg.message_id, "subject": msg.subject} for msg in bounce_days_7],
-            "last_5": [{"mid": msg.message_id, "subject": msg.subject} for msg in bounce_last_5],
+            "days_7": [
+                {
+                    "mid": msg.message_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
+                for msg in bounce_days_7
+            ],
+            "last_5": [
+                {
+                    "mid": msg.message_id,
+                    "subject": msg.subject,
+                    "received_at": msg.received_at,
+                }
+                for msg in bounce_last_5
+            ],
         },
         "email_out": {
             "count": len(email_out_all),
@@ -127,6 +164,7 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "subject": msg.subject,
                     "sent_successful": len(msg.sent_successful),
                     "sent_failed": len(msg.sent_failed),
+                    "sent_at": msg.sent_at,
                 }
                 for msg in email_out_hours_24
             ],
@@ -136,6 +174,7 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "subject": msg.subject,
                     "sent_successful": len(msg.sent_successful),
                     "sent_failed": len(msg.sent_failed),
+                    "sent_at": msg.sent_at,
                 }
                 for msg in email_out_days_7
             ],
@@ -145,13 +184,14 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
                     "subject": msg.subject,
                     "sent_successful": len(msg.sent_successful),
                     "sent_failed": len(msg.sent_failed),
+                    "sent_at": msg.sent_at,
                 }
                 for msg in email_out_all[:5]
             ],
         },
         "errors": {
-            "hours_24": [log.id for log in errors_hours_24],
-            "days_7": [log.id for log in errors_days_7],
+            "hours_24": [{"id": log.id, "timestamp": log.timestamp} for log in errors_hours_24],
+            "days_7": [{"id": log.id, "timestamp": log.timestamp} for log in errors_days_7],
             "last_5": [
                 {
                     "id": log.id,
@@ -163,8 +203,8 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
             ],
         },
         "warnings": {
-            "hours_24": [log.id for log in warnings_hours_24],
-            "days_7": [log.id for log in warnings_days_7],
+            "hours_24": [{"id": log.id, "timestamp": log.timestamp} for log in warnings_hours_24],
+            "days_7": [{"id": log.id, "timestamp": log.timestamp} for log in warnings_days_7],
             "last_5": [
                 {
                     "id": log.id,

--- a/castmail2list/status.py
+++ b/castmail2list/status.py
@@ -4,6 +4,7 @@
 
 """Functions and operations to collect reports about different parts of Castmail2List."""
 
+from . import __version__
 from .models import MailingList
 from .utils import (
     get_all_incoming_messages,
@@ -61,6 +62,7 @@ def status_complete() -> dict:  # pylint: disable=too-many-locals
     warnings_last_5 = get_log_entries(exact=True, level="warning")[:5]
 
     status: dict = {
+        "_version_app": __version__,
         "lists": {
             "count": lists_count(),
         },

--- a/castmail2list/templates/index.html
+++ b/castmail2list/templates/index.html
@@ -19,6 +19,7 @@
         {%- for msg in stats.email_in.last_5 %}
         <li>
           <a href="{{ url_for('messages.show_unique', message_id=msg.mid, list_id=msg.list_id) }}">{{ msg.subject }}</a>
+          (<abbr title="{{ msg.received_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ msg.received_at | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>
@@ -37,6 +38,7 @@
         {%- for msg in stats.email_out.last_5 %}
         <li>
           <a href="{{ url_for('messages.show', message_id=msg.mid) }}">{{ msg.subject }}</a>
+          (<abbr title="{{ msg.sent_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ msg.sent_at | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>
@@ -53,10 +55,9 @@
       <ul>
         {%- for error in stats.errors.last_5 %}
         <li>
-          <a href="{{ url_for('logs.detail', log_id=error.id) }}">
-            {{ error.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC") -}}
-          </a>
+          <a href="{{ url_for('logs.detail', log_id=error.id) }}">{{ error.message | truncate(80) }}</a>
           ({{ error.event }})
+          (<abbr title="{{ error.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ error.timestamp | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>
@@ -73,10 +74,9 @@
       <ul>
         {%- for warning in stats.warnings.last_5 %}
         <li>
-          <a href="{{ url_for('logs.detail', log_id=warning.id) }}">
-            {{ warning.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC") -}}
-          </a>
+          <a href="{{ url_for('logs.detail', log_id=warning.id) }}">{{ warning.message | truncate(80) }}</a>
           ({{ warning.event }})
+          (<abbr title="{{ warning.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ warning.timestamp | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>
@@ -93,7 +93,8 @@
       <ul>
         {%- for msg in stats.email_in_failures.last_5 %}
         <li>
-          <a href="{{ url_for('messages.show', message_id=msg.mid) }}">{{ msg.subject }}</a>
+          <a href="{{ url_for('messages.show_unique', message_id=msg.mid, list_id=msg.list_id) }}">{{ msg.subject }}</a>
+          (<abbr title="{{ msg.received_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ msg.received_at | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>
@@ -110,7 +111,8 @@
       <ul>
         {%- for msg in stats.bounces.last_5 %}
         <li>
-          <a href="{{ url_for('messages.show', message_id=msg.mid) }}">{{ msg.subject }}</a>
+          <a href="{{ url_for('messages.show_unique', message_id=msg.mid, list_id=msg.list_id) }}">{{ msg.bounced_recipient }}</a>
+          (<abbr title="{{ msg.received_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">{{ msg.received_at | time_ago }}</abbr>)
         </li>
         {%- endfor %}
       </ul>

--- a/castmail2list/utils.py
+++ b/castmail2list/utils.py
@@ -629,6 +629,22 @@ def get_app_bin_dir() -> Path:
     return Path(sys.executable).parent
 
 
+def time_ago(dt: datetime) -> str:
+    """Return a human-readable relative time string for a datetime, e.g. '2 days ago'.
+
+    Args:
+        dt (datetime): The datetime to compare against now.
+
+    Returns:
+        str: A human-readable relative time string.
+    """
+    from ago import human  # noqa: PLC0415
+
+    # ago uses naive datetime.now() internally; strip tzinfo to avoid TypeError
+    naive_dt = dt.replace(tzinfo=None) if dt.tzinfo else dt
+    return human(naive_dt, precision=1)
+
+
 def get_user_config_path(name: str = "castmail2list", file: str = "") -> str:
     """
     Get the user configuration directory for the application.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "jsonschema>=4.25.1,<5",
     "gunicorn>=26,<27",
     "platformdirs>=4.5.0,<5",
+    "ago>=0.1.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ago"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/3e/e69f3d5ff15f0dd779b79ba21d6862fba4bf8674f5ead618fc188832a148/ago-0.1.1.tar.gz", hash = "sha256:7b09d70d3b698bd7dd6ed952583430943b91569068deb2a180480e411bc90c47", size = 8903, upload-time = "2026-07-02T17:17:01.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/78/ae7a7f44bbdfea219e982d834a96d0428e7afbaafd55e4e19db3020fde20/ago-0.1.1-py3-none-any.whl", hash = "sha256:3db9b39b212c0e035d6aaa0a00e738438820b7df40b3e327f395897c457b900c", size = 7449, upload-time = "2026-07-02T17:17:00.567Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.5"
 source = { registry = "https://pypi.org/simple" }
@@ -84,6 +93,7 @@ name = "castmail2list"
 version = "0.9.1"
 source = { editable = "." }
 dependencies = [
+    { name = "ago" },
     { name = "email-validator" },
     { name = "flask" },
     { name = "flask-babel" },
@@ -114,6 +124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ago", specifier = ">=0.1.1" },
     { name = "email-validator", specifier = ">=2.3.0,<3" },
     { name = "flask", specifier = ">=3.1.2,<4" },
     { name = "flask-babel", specifier = ">=4.0.0,<5" },


### PR DESCRIPTION
Make dashboard and /status API endpoint more informative and helpful.

Especially on the Dashboard, the user will now be more informed about how recent events were (by human-readable timedeltas). We also focus on the most relevant information per event.

Also fixes #101 